### PR TITLE
chore: rename api_operations class 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 /tmp/
 
 .DS_Store
+.idea
 
 # Used by dotenv library to load environment variables.
 .env

--- a/lib/xendit/api_operations.rb
+++ b/lib/xendit/api_operations.rb
@@ -4,7 +4,7 @@ require 'faraday'
 require 'json'
 
 module Xendit
-  class ApiOperations
+  class APIOperations
     class << self
       def get(url, params = nil)
         conn = create_connection

--- a/lib/xendit/resources/invoice.rb
+++ b/lib/xendit/resources/invoice.rb
@@ -14,7 +14,7 @@ module Xendit
         raise ArgumentError, 'invoice_id is required and should be a string' \
             if invoice_id.nil? || !invoice_id.is_a?(String)
 
-        resp = Xendit::ApiOperations.get "v2/invoices/#{invoice_id}"
+        resp = Xendit::APIOperations.get "v2/invoices/#{invoice_id}"
         Xendit::Response.handle_error_response resp
 
         JSON.parse resp.body
@@ -39,7 +39,7 @@ module Xendit
                (!invoice_params[:amount].is_a?(Integer) &&
                !invoice_params[:amount].is_a?(Float))
 
-        resp = Xendit::ApiOperations.post('v2/invoices', **invoice_params)
+        resp = Xendit::APIOperations.post('v2/invoices', **invoice_params)
         Xendit::Response.handle_error_response resp
 
         JSON.parse resp.body
@@ -51,14 +51,14 @@ module Xendit
         raise ArgumentError, 'invoice_id is required and should be a string' \
             if invoice_id.nil? || !invoice_id.is_a?(String)
 
-        resp = Xendit::ApiOperations.post "invoices/#{invoice_id}/expire!"
+        resp = Xendit::APIOperations.post "invoices/#{invoice_id}/expire!"
         Xendit::Response.handle_error_response resp
 
         JSON.parse resp.body
       end
 
       def get_all(filter_params = nil)
-        resp = Xendit::ApiOperations.get('v2/invoices', filter_params)
+        resp = Xendit::APIOperations.get('v2/invoices', filter_params)
         Xendit::Response.handle_error_response resp
 
         JSON.parse resp.body

--- a/spec/xendit/api_operations_spec.rb
+++ b/spec/xendit/api_operations_spec.rb
@@ -2,7 +2,7 @@
 
 require 'xendit/api_operations'
 
-describe Xendit::ApiOperations do
+describe Xendit::APIOperations do
   describe '.create_connection' do
     it 'should returns a connection object' do
       conn = described_class.send(:create_connection)

--- a/spec/xendit/resources/invoice_spec.rb
+++ b/spec/xendit/resources/invoice_spec.rb
@@ -41,7 +41,7 @@ describe Xendit::Invoice do
       end
 
       it 'should return the created invoice object' do
-        allow(Xendit::ApiOperations).to receive(:post).with(url, invoice_params).and_return(api_operation_response)
+        allow(Xendit::APIOperations).to receive(:post).with(url, invoice_params).and_return(api_operation_response)
 
         result = described_class.create invoice_params
         expect(result).to eq(invoice)
@@ -73,7 +73,7 @@ describe Xendit::Invoice do
     end
 
     it 'should return a invoice object' do
-      allow(Xendit::ApiOperations).to receive(:get).with(url).and_return(api_operation_response)
+      allow(Xendit::APIOperations).to receive(:get).with(url).and_return(api_operation_response)
 
       result = described_class.get invoice['id']
       expect(result).to eq(invoice)
@@ -90,7 +90,7 @@ describe Xendit::Invoice do
     end
 
     it 'should return invoice object(s)' do
-      allow(Xendit::ApiOperations).to receive(:get).with(url, nil).and_return(api_operation_response)
+      allow(Xendit::APIOperations).to receive(:get).with(url, nil).and_return(api_operation_response)
 
       result = described_class.get_all
       expect(result).to eq(invoice)
@@ -108,7 +108,7 @@ describe Xendit::Invoice do
     end
 
     it 'should return the expired invoice object' do
-      allow(Xendit::ApiOperations).to receive(:post).with(url).and_return(api_operation_response)
+      allow(Xendit::APIOperations).to receive(:post).with(url).and_return(api_operation_response)
 
       result = described_class.expire invoice['id']
       expect(result).to eq(expired_invoice)


### PR DESCRIPTION
Based on https://rubystyle.guide/#camelcase-classes and to be consistent with [errors class](https://github.com/xendit/xendit-ruby/blob/master/lib/xendit/errors.rb#L4)