### PR TITLE
Fix typo spec API key and add "teardown"

### DIFF
--- a/spec/xendit_spec.rb
+++ b/spec/xendit_spec.rb
@@ -3,10 +3,15 @@
 require 'xendit'
 
 describe Xendit do
+  after do
+    Xendit.api_key = nil
+    Xendit.base_url = nil
+  end
+
   describe 'API key' do
     let(:api_key) { 'this_is_my_api_key' }
 
-    context 'given no API URL provided' do
+    context 'given no API key provided' do
       it 'should return nil' do
         expect(described_class.api_key).to be_nil
       end


### PR DESCRIPTION
- There was a typo in the test, it should say "API **key**" instead of "API **URL**"
- Add "teardown" that will clear the `api_key` and `base_url` which cause the test failing because of sharing the same resource
  - I put it in `after` instead of `before`, because for me, it seems more make sense to say it: not properly "teardown" instead of not properly  "setup"