### PR TITLE
Fix deprecation warning from Faraday

### DIFF
--- a/lib/xendit/api_operations.rb
+++ b/lib/xendit/api_operations.rb
@@ -23,7 +23,7 @@ module Xendit
           url: Xendit.base_url,
           headers: {'Content-Type' => 'application/json'}
         ) do |conn|
-          conn.basic_auth(Xendit.api_key, '')
+          conn.request(:basic_auth, Xendit.api_key, '')
         end
       end
     end


### PR DESCRIPTION
```
WARNING: `Faraday::Connection#basic_auth` is deprecated; it will be removed in version 2.0.                                                    
While initializing your connection, use `#request(:basic_auth, ...)` instead.
```