### PR TITLE
feat: Add PaymentRequest API support and bump version to 1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,3 +83,82 @@ Expire an invoice
 # expire an invoice
 expired_invoice = Xendit::Invoice.expire '5efda8a20425db620ec35f43'
 ```
+Payment Request Service
+> New in version 1.1.0
+
+The `PaymentRequest` resource provides a unified way to create and retrieve card payments, e-wallets, QRIS, reusable codes, manual capture, and advanced flows such as PAY.
+
+Create a Card Payment
+```ruby
+params = {
+  reference_id: "order_#{Time.now.to_i}",
+  type: 'PAY',
+  country: 'ID',
+  currency: 'IDR',
+  request_amount: 100_000,
+  capture_method: 'AUTOMATIC',
+  channel_code: 'CARDS',
+  channel_properties: {
+    mid_label: 'TEST_MID',
+    card_details: {
+      cvn: '123',
+      card_number: '4000000000001091',
+      expiry_year: '2025',
+      expiry_month: '12'
+    }
+  },
+  description: 'Card payment example'
+}
+
+payment = Xendit::PaymentRequest.create(params)
+
+```
+Get a Payment Request
+```ruby
+payment = Xendit::PaymentRequest.get('payment_request_id')
+```
+Create Payment with Custom Headers (XenPlatform)
+```ruby
+headers = {
+  api_version: '2024-11-11',
+  for_user_id: 'sub-account-id', #(optional)
+  with_split_rule: 'split-rule-id' #(optional)
+}
+
+payment = Xendit::PaymentRequest.create(params, headers: headers)
+```
+
+Manual Capture Example
+```ruby
+params[:capture_method] = 'MANUAL'
+
+manual_payment = Xendit::PaymentRequest.create(params)
+```
+E-Wallet Example (GCash)
+```ruby
+ewallet_params = {
+  reference_id: "gcash_#{Time.now.to_i}",
+  type: 'PAY',
+  country: 'PH',
+  currency: 'PHP',
+  request_amount: 1000,
+  channel_code: 'GCASH',
+  channel_properties: {
+    success_redirect_url: 'https://yourapp.com/success',
+    failure_redirect_url: 'https://yourapp.com/failure'
+  }
+}
+
+payment = Xendit::PaymentRequest.create(ewallet_params)
+```
+
+Error Handling
+```ruby
+begin
+  Xendit::PaymentRequest.create(params)
+rescue Xendit::APIError => e
+  puts "Status: #{e.http_status}"
+  puts "Code: #{e.error_code}"
+  puts "Message: #{e.error_message}"
+end
+```

--- a/examples/payment_request.rb
+++ b/examples/payment_request.rb
@@ -1,0 +1,275 @@
+# frozen_string_literal: true
+
+require_relative '../lib/xendit' # require 'xendit'
+
+Xendit.api_key = 'your_api_key'
+
+begin
+  # Example 1: Create a Card Payment (PAY type)
+  puts '\n=== Creating Card Payment Request ==='
+  
+  card_payment_params = {
+    reference_id: "order_#{Time.now.to_i}",
+    type: 'PAY',
+    country: 'ID',
+    currency: 'IDR',
+    request_amount: 100_000,
+    capture_method: 'AUTOMATIC',
+    channel_code: 'CARDS',
+    channel_properties: {
+      mid_label: 'CTV_TEST',
+      card_details: {
+        cvn: '123',
+        card_number: '4000000000001091',
+        expiry_year: '2025',
+        expiry_month: '12',
+        cardholder_first_name: 'John',
+        cardholder_last_name: 'Doe',
+        cardholder_email: 'john.doe@example.com',
+        cardholder_phone_number: '+628123456789'
+      },
+      skip_three_ds: false,
+      failure_return_url: 'https://yoursite.com/failure',
+      success_return_url: 'https://yoursite.com/success'
+    },
+    description: 'Payment for Order #123456',
+    metadata: {
+      order_id: '123456',
+      customer_type: 'premium'
+    }
+  }
+
+  created_payment = Xendit::PaymentRequest.create(card_payment_params)
+  puts 'Created Payment Request:'
+  puts JSON.pretty_generate(created_payment)
+
+  payment_request_id = created_payment['payment_request_id']
+
+  # Example 2: Get Payment Request by ID
+  puts "\n=== Getting Payment Request ==="
+
+  payment = Xendit::PaymentRequest.get(payment_request_id)
+  puts 'Payment Request:'
+  puts JSON.pretty_generate(payment)
+  puts "Status: #{payment['status']}"
+
+  # Example 3: Create with Custom Headers (XenPlatform)
+  puts "\n=== Creating Payment with Custom Headers ==="
+
+  custom_headers = {
+    api_version: '2024-11-11',
+    for_user_id: 'user-123', # Sub-account user ID
+    with_split_rule: 'split-rule-456' # Split rule ID
+  }
+
+  platform_payment_params = {
+    reference_id: "platform_order_#{Time.now.to_i}",
+    type: 'PAY',
+    country: 'ID',
+    currency: 'IDR',
+    request_amount: 250_000,
+    capture_method: 'AUTOMATIC',
+    channel_code: 'CARDS',
+    channel_properties: {
+      mid_label: 'CTV_TEST',
+      card_details: {
+        cvn: '123',
+        card_number: '4000000000001091',
+        expiry_year: '2025',
+        expiry_month: '12'
+      }
+    },
+    description: 'Platform payment with split'
+  }
+
+  platform_payment = Xendit::PaymentRequest.create(platform_payment_params, headers: custom_headers)
+  puts 'Platform Payment Created:'
+  puts JSON.pretty_generate(platform_payment)
+
+  # Example 4: Create Manual Capture Payment
+  puts '\n=== Creating Manual Capture Payment ==='
+
+  manual_capture_params = {
+    reference_id: "manual_#{Time.now.to_i}",
+    type: 'PAY',
+    country: 'ID',
+    currency: 'IDR',
+    request_amount: 150_000,
+    capture_method: 'MANUAL', # Requires manual capture later
+    channel_code: 'CARDS',
+    channel_properties: {
+      mid_label: 'CTV_TEST',
+      card_details: {
+        cvn: '123',
+        card_number: '4000000000001091',
+        expiry_year: '2025',
+        expiry_month: '12'
+      }
+    },
+    description: 'Manual capture payment'
+  }
+
+  manual_payment = Xendit::PaymentRequest.create(manual_capture_params)
+  puts 'Manual Capture Payment Created:'
+  puts JSON.pretty_generate(manual_payment)
+  puts "Status: #{manual_payment['status']}"
+
+  # Example 5: Create Reusable Payment Code
+  puts '\n=== Creating Reusable Payment Code ==='
+
+  reusable_params = {
+    reference_id: "reusable_#{Time.now.to_i}",
+    type: 'REUSABLE_PAYMENT_CODE',
+    country: 'ID',
+    currency: 'IDR',
+    # NOTE: request_amount is not required for REUSABLE_PAYMENT_CODE
+    channel_code: 'QRIS',
+    channel_properties: {
+      qr_string: 'sample_qr_string'
+    },
+    description: 'Reusable QR code for multiple payments'
+  }
+
+  reusable_payment = Xendit::PaymentRequest.create(reusable_params)
+  puts 'Reusable Payment Code Created:'
+  puts JSON.pretty_generate(reusable_payment)
+
+  # Example 6: Create E-Wallet Payment (GCash)
+  puts '\n=== Creating E-Wallet Payment (GCash) ==='
+
+  ewallet_params = {
+    reference_id: "gcash_#{Time.now.to_i}",
+    type: 'PAY',
+    country: 'PH',
+    currency: 'PHP',
+    request_amount: 1000,
+    capture_method: 'AUTOMATIC',
+    channel_code: 'GCASH',
+    channel_properties: {
+      success_redirect_url: 'https://yoursite.com/success',
+      failure_redirect_url: 'https://yoursite.com/failure'
+    },
+    description: 'GCash payment'
+  }
+
+  ewallet_payment = Xendit::PaymentRequest.create(ewallet_params)
+  puts 'E-Wallet Payment Created:'
+  puts JSON.pretty_generate(ewallet_payment)
+
+  # Get the status
+  ewallet_status = Xendit::PaymentRequest.get(ewallet_payment['payment_request_id'])
+  puts "E-Wallet Payment Status: #{ewallet_status['status']}"
+
+  # Example 7: Create with Customer Details
+  puts '\n=== Creating Payment with Customer Details ==='
+
+  customer_payment_params = {
+    reference_id: "customer_#{Time.now.to_i}",
+    type: 'PAY',
+    country: 'ID',
+    currency: 'IDR',
+    request_amount: 100_000,
+    capture_method: 'AUTOMATIC',
+    channel_code: 'CARDS',
+    channel_properties: {
+      mid_label: 'CTV_TEST',
+      card_details: {
+        cvn: '123',
+        card_number: '4000000000001091',
+        expiry_year: '2025',
+        expiry_month: '12'
+      }
+    },
+    customer: {
+      type: 'INDIVIDUAL',
+      reference_id: "customer_ref_#{Time.now.to_i}",
+      email: 'customer@example.com',
+      mobile_number: '+628123456789',
+      individual_detail: {
+        given_names: 'John',
+        surname: 'Doe',
+        nationality: 'ID',
+        date_of_birth: '1990-01-01'
+      }
+    },
+    description: 'Payment with customer details'
+  }
+
+  customer_payment = Xendit::PaymentRequest.create(customer_payment_params)
+  puts 'Payment with Customer Details Created:'
+  puts JSON.pretty_generate(customer_payment)
+
+  # Example 8: PAY_AND_SAVE type (Save card for future use)
+  puts '\n=== Creating PAY_AND_SAVE Payment ==='
+
+  pay_and_save_params = {
+    reference_id: "pay_save_#{Time.now.to_i}",
+    type: 'PAY_AND_SAVE', # Will save payment token for reuse
+    country: 'ID',
+    currency: 'IDR',
+    request_amount: 200_000,
+    capture_method: 'AUTOMATIC',
+    channel_code: 'CARDS',
+    channel_properties: {
+      mid_label: 'CTV_TEST',
+      card_details: {
+        cvn: '123',
+        card_number: '4000000000001091',
+        expiry_year: '2025',
+        expiry_month: '12'
+      }
+    },
+    description: 'Payment that saves card for future'
+  }
+
+  pay_and_save = Xendit::PaymentRequest.create(pay_and_save_params)
+  puts 'PAY_AND_SAVE Payment Created:'
+  puts JSON.pretty_generate(pay_and_save)
+  puts "Payment Token ID: #{pay_and_save['payment_token_id']}" if pay_and_save['payment_token_id']
+
+  # Example 9: Get Payment with Custom Headers
+  puts '\n=== Getting Payment with Custom Headers ==='
+
+  get_headers = {
+    api_version: '2024-11-11',
+    for_user_id: 'user-123'
+  }
+
+  payment_with_headers = Xendit::PaymentRequest.get(
+    payment_request_id,
+    headers: get_headers
+  )
+  puts 'Payment Retrieved with Custom Headers:'
+  puts "Payment ID: #{payment_with_headers['payment_request_id']}"
+  puts "Status: #{payment_with_headers['status']}"
+  puts "Amount: #{payment_with_headers['request_amount']}"
+
+  # Example 10: Checking Payment Status
+  puts '\n=== Checking Payment Statuses ==='
+
+  statuses = {
+    'ACCEPTING_PAYMENTS' => 'Payment is waiting to be paid',
+    'REQUIRES_ACTION' => 'Additional action needed from customer',
+    'AUTHORIZED' => 'Payment authorized (for MANUAL capture)',
+    'SUCCEEDED' => 'Payment successful',
+    'FAILED' => 'Payment failed',
+    'CANCELED' => 'Payment canceled',
+    'EXPIRED' => 'Payment expired'
+  }
+  puts statuses
+
+  current_payment = Xendit::PaymentRequest.get(payment_request_id)
+  current_status = current_payment['status']
+
+  puts "Current Payment Status: #{current_status}"
+  puts "Status Description: #{statuses[current_status]}"
+  puts "Failure Code: #{current_payment['failure_code']}" if current_payment['failure_code']
+rescue Xendit::APIError => e
+  puts '\nAPI Error occurred:'
+  puts "Status: #{e.http_status}"
+  puts "Error Code: #{e.error_code}"
+  puts "Message: #{e.error_message}"
+rescue ArgumentError => e
+  puts '\nValidation Error:'
+  puts e.message
+end

--- a/examples/payout.rb
+++ b/examples/payout.rb
@@ -1,0 +1,314 @@
+# frozen_string_literal: true
+
+require_relative '../lib/xendit' # require 'xendit'
+
+Xendit.api_key = 'your_api_key'
+
+begin
+  # Example 1: Create a Bank Payout (BCA Indonesia)
+  puts '\n=== Creating Bank Payout (BCA) ==='
+
+  bank_payout_params = {
+    reference_id: "payout_#{Time.now.to_i}",
+    channel_code: 'ID_BCA',
+    channel_properties: {
+      account_number: '000000000099',
+      account_holder_name: 'Michael Chen'
+    },
+    amount: 100_000,
+    description: 'December salary payout',
+    currency: 'IDR'
+  }
+
+  # Using reference_id as idempotency key
+  created_payout = Xendit::Payout.create(
+    bank_payout_params,
+    headers: {idempotency_key: bank_payout_params[:reference_id]}
+  )
+  puts 'Created Payout:'
+  puts JSON.pretty_generate(created_payout)
+  puts "Payout ID: #{created_payout['id']}"
+  puts "Status: #{created_payout['status']}"
+
+  payout_id = created_payout['id']
+
+  # Example 2: Get Payout by ID
+  puts "\n=== Getting Payout by ID ==="
+
+  payout = Xendit::Payout.get(payout_id)
+  puts 'Payout Details:'
+  puts JSON.pretty_generate(payout)
+  puts "Status: #{payout['status']}"
+  puts "Amount: #{payout['amount']}"
+  puts "Estimated Arrival: #{payout['estimated_arrival_time']}"
+
+  # Example 3: Get Payout by Reference ID
+  puts "\n=== Getting Payout by Reference ID ==="
+
+  payouts_by_ref = Xendit::Payout.get_by_reference_id(bank_payout_params[:reference_id])
+  puts 'Payouts with Reference ID:'
+  puts JSON.pretty_generate(payouts_by_ref)
+
+  # Example 4: Create E-Wallet Payout (OVO)
+  puts '\n=== Creating E-Wallet Payout (OVO) ==='
+
+  ewallet_payout_params = {
+    reference_id: "ovo_payout_#{Time.now.to_i}",
+    channel_code: 'ID_OVO',
+    channel_properties: {
+      account_number: '081234567890',
+      account_holder_name: 'Sarah Johnson'
+    },
+    amount: 50_000,
+    description: 'Cashback payment',
+    currency: 'IDR'
+  }
+
+  ewallet_payout = Xendit::Payout.create(
+    ewallet_payout_params,
+    headers: {idempotency_key: ewallet_payout_params[:reference_id]}
+  )
+  puts 'E-Wallet Payout Created:'
+  puts JSON.pretty_generate(ewallet_payout)
+
+  # Example 5: Create Payout with Email Notifications
+  puts '\n=== Creating Payout with Email Notifications ==='
+
+  payout_with_email_params = {
+    reference_id: "email_payout_#{Time.now.to_i}",
+    channel_code: 'ID_MANDIRI',
+    channel_properties: {
+      account_number: '1234567890',
+      account_holder_name: 'John Doe'
+    },
+    amount: 250_000,
+    description: 'Commission payment',
+    currency: 'IDR',
+    receipt_notification: {
+      email_to: ['recipient@example.com'],
+      email_cc: ['manager@example.com'],
+      email_bcc: ['accounting@example.com']
+    }
+  }
+
+  payout_with_email = Xendit::Payout.create(
+    payout_with_email_params,
+    headers: {idempotency_key: payout_with_email_params[:reference_id]}
+  )
+  puts 'Payout with Email Notifications Created:'
+  puts JSON.pretty_generate(payout_with_email)
+
+  # Example 6: Create Payout with Metadata
+  puts '\n=== Creating Payout with Metadata ==='
+
+  payout_with_metadata_params = {
+    reference_id: "metadata_payout_#{Time.now.to_i}",
+    channel_code: 'ID_BNI',
+    channel_properties: {
+      account_number: '9876543210',
+      account_holder_name: 'Jane Smith'
+    },
+    amount: 150_000,
+    description: 'Vendor payment',
+    currency: 'IDR',
+    metadata: {
+      order_id: '123456',
+      vendor_id: 'V789',
+      payment_type: 'vendor_payment',
+      department: 'procurement'
+    }
+  }
+
+  payout_with_metadata = Xendit::Payout.create(
+    payout_with_metadata_params,
+    headers: {idempotency_key: payout_with_metadata_params[:reference_id]}
+  )
+  puts 'Payout with Metadata Created:'
+  puts JSON.pretty_generate(payout_with_metadata)
+  puts "Metadata: #{payout_with_metadata['metadata']}"
+
+  # Example 7: Create PHP Payout (Philippines)
+  puts '\n=== Creating PHP Payout (Philippines) ==='
+
+  php_payout_params = {
+    reference_id: "php_payout_#{Time.now.to_i}",
+    channel_code: 'PH_BDO',
+    channel_properties: {
+      account_number: '1234567890',
+      account_holder_name: 'Maria Santos'
+    },
+    amount: 5000.50, # PHP can have 2 decimal places
+    description: 'Freelancer payment',
+    currency: 'PHP'
+  }
+
+  php_payout = Xendit::Payout.create(
+    php_payout_params,
+    headers: {idempotency_key: php_payout_params[:reference_id]}
+  )
+  puts 'PHP Payout Created:'
+  puts JSON.pretty_generate(php_payout)
+
+  # Example 8: Create MYR Payout with DuitNow (Malaysia)
+  puts '\n=== Creating MYR Payout with DuitNow ==='
+
+  duitnow_payout_params = {
+    reference_id: "duitnow_#{Time.now.to_i}",
+    channel_code: 'MY_DUITNOW',
+    channel_properties: {
+      account_number: '60123456789', # Mobile number
+      account_holder_name: 'Ahmad Abdullah',
+      account_type: 'MOBILE_NO' # Using mobile number as proxy
+    },
+    amount: 100.50, # MYR can have 2 decimal places
+    description: 'Refund payment',
+    currency: 'MYR'
+  }
+
+  duitnow_payout = Xendit::Payout.create(
+    duitnow_payout_params,
+    headers: {idempotency_key: duitnow_payout_params[:reference_id]}
+  )
+  puts 'DuitNow Payout Created:'
+  puts JSON.pretty_generate(duitnow_payout)
+
+  # Example 9: Create THB Payout (Thailand)
+  puts '\n=== Creating THB Payout (Thailand) ==='
+
+  thb_payout_params = {
+    reference_id: "thb_payout_#{Time.now.to_i}",
+    channel_code: 'TH_BANGKOK_BANK',
+    channel_properties: {
+      account_number: '1234567890',
+      account_holder_name: 'Somchai Patel',
+      account_type: 'BANK_ACCOUNT'
+    },
+    amount: 1500.75, # THB can have 2 decimal places
+    description: 'Service payment',
+    currency: 'THB'
+  }
+
+  thb_payout = Xendit::Payout.create(
+    thb_payout_params,
+    headers: {idempotency_key: thb_payout_params[:reference_id]}
+  )
+  puts 'THB Payout Created:'
+  puts JSON.pretty_generate(thb_payout)
+
+  # Example 10: Create Payout with XenPlatform (Sub-account)
+  puts '\n=== Creating Payout with XenPlatform ==='
+
+  platform_payout_params = {
+    reference_id: "platform_payout_#{Time.now.to_i}",
+    channel_code: 'ID_BCA',
+    channel_properties: {
+      account_number: '111222333444',
+      account_holder_name: 'Platform User'
+    },
+    amount: 500_000,
+    description: 'Sub-account payout',
+    currency: 'IDR'
+  }
+
+  platform_headers = {
+    idempotency_key: platform_payout_params[:reference_id],
+    for_user_id: 'sub-account-user-123' # XenPlatform sub-account ID
+  }
+
+  platform_payout = Xendit::Payout.create(
+    platform_payout_params,
+    headers: platform_headers
+  )
+  puts 'Platform Payout Created:'
+  puts JSON.pretty_generate(platform_payout)
+
+  # Example 11: Checking Payout Status
+  puts '\n=== Checking Payout Status ==='
+
+  statuses = {
+    'ACCEPTED' => 'Payout accepted, waiting to be processed',
+    'REQUESTED' => 'Payout sent to the channel for processing',
+    'FAILED' => 'Payout failed',
+    'SUCCEEDED' => 'Payout successful',
+    'CANCELLED' => 'Payout cancelled',
+    'REVERSED' => 'Payout reversed by channel'
+  }
+
+  puts 'Available Payout Statuses:'
+  statuses.each { |status, description| puts "  #{status}: #{description}" }
+
+  current_payout = Xendit::Payout.get(payout_id)
+  current_status = current_payout['status']
+
+  puts "\nCurrent Payout Status: #{current_status}"
+  puts "Status Description: #{statuses[current_status]}"
+
+  if current_payout['failure_code']
+    puts "Failure Code: #{current_payout['failure_code']}"
+
+    failure_codes = {
+      'INSUFFICIENT_BALANCE' => 'Client has insufficient balance',
+      'INVALID_DESTINATION' => 'Recipient account does not exist/is invalid',
+      'REJECTED_BY_CHANNEL' => 'Failed due to channel error',
+      'TEMPORARY_TRANSFER_ERROR' => 'Channel networks temporary error',
+      'TRANSFER_ERROR' => 'Fatal error while processing',
+      'UNKNOWN_BANK_NETWORK_ERROR' => 'Undocumented bank error',
+      'DESTINATION_MAXIMUM_LIMIT' => 'Amount exceeds recipient limit'
+    }
+
+    puts "Failure Reason: #{failure_codes[current_payout['failure_code']]}"
+  end
+
+  # Example 12: Multiple Payouts with Different Idempotency Keys
+  puts '\n=== Creating Multiple Payouts ==='
+
+  3.times do |i|
+    multi_payout_params = {
+      reference_id: "batch_payout_#{Time.now.to_i}_#{i}",
+      channel_code: 'ID_BCA',
+      channel_properties: {
+        account_number: "00000000#{i.to_s.rjust(4, '0')}",
+        account_holder_name: "Employee #{i + 1}"
+      },
+      amount: 75_000 + (i * 25_000),
+      description: "Batch payout #{i + 1}",
+      currency: 'IDR'
+    }
+
+    batch_payout = Xendit::Payout.create(
+      multi_payout_params,
+      headers: {idempotency_key: multi_payout_params[:reference_id]}
+    )
+
+    puts "\nBatch Payout #{i + 1} Created:"
+    puts "  ID: #{batch_payout['id']}"
+    puts "  Amount: #{batch_payout['amount']}"
+    puts "  Status: #{batch_payout['status']}"
+  end
+
+  # Example 13: Get Payout with XenPlatform Headers
+  puts '\n=== Getting Payout with XenPlatform Headers ==='
+
+  get_platform_headers = {
+    for_user_id: 'sub-account-user-123'
+  }
+
+  platform_payout_details = Xendit::Payout.get(
+    platform_payout['id'],
+    headers: get_platform_headers
+  )
+
+  puts 'Platform Payout Details:'
+  puts "  Payout ID: #{platform_payout_details['id']}"
+  puts "  Business ID: #{platform_payout_details['business_id']}"
+  puts "  Amount: #{platform_payout_details['amount']}"
+  puts "  Status: #{platform_payout_details['status']}"
+rescue Xendit::APIError => e
+  puts '\nAPI Error occurred:'
+  puts "Status: #{e.http_status}"
+  puts "Error Code: #{e.error_code}"
+  puts "Message: #{e.error_message}"
+rescue ArgumentError => e
+  puts '\nValidation Error:'
+  puts e.message
+end

--- a/lib/xendit/api_operations.rb
+++ b/lib/xendit/api_operations.rb
@@ -6,25 +6,29 @@ require 'json'
 module Xendit
   class APIOperations
     class << self
-      def get(url, params = nil)
-        conn = create_connection
+      def get(url, params = nil, headers: {})
+        conn = create_connection(headers)
         conn.get url, params
       end
 
-      def post(url, **params)
-        conn = create_connection
+      def post(url, headers: {}, **params)
+        conn = create_connection(headers)
         conn.post url, JSON.generate(params)
       end
 
       private
 
-      def create_connection
+      def create_connection(custom_headers = {})
         Faraday.new(
           url: Xendit.base_url,
-          headers: {'Content-Type' => 'application/json'}
+          headers: default_headers.merge(custom_headers)
         ) do |conn|
           conn.basic_auth(Xendit.api_key, '')
         end
+      end
+
+      def default_headers
+        {'Content-Type' => 'application/json'}
       end
     end
   end

--- a/lib/xendit/errors.rb
+++ b/lib/xendit/errors.rb
@@ -9,7 +9,7 @@ module Xendit
       @error_message = error_message
       @http_status = http_status
 
-      super to_s
+      super(to_s)
     end
 
     def to_s

--- a/lib/xendit/payout/validator.rb
+++ b/lib/xendit/payout/validator.rb
@@ -1,0 +1,153 @@
+# frozen_string_literal: true
+
+module Xendit
+  class Payout
+    module Validator
+      class << self
+        def validate_payout_id(payout_id)
+          raise ArgumentError, 'payout_id is required and should be a string' \
+            if payout_id.nil? || !payout_id.is_a?(String)
+
+          raise ArgumentError, 'payout_id should be 29 characters long' \
+            if payout_id.length != 29
+        end
+
+        def validate_payout_params(params)
+          validate_core_fields(params)
+          validate_channel_properties(params[:channel_properties])
+          validate_optional_fields(params)
+        end
+
+        def validate_string_length(value, field_name, min_length, max_length)
+          return unless value
+
+          length = value.to_s.length
+          return if length >= min_length && length <= max_length
+
+          raise ArgumentError,
+                "#{field_name} must be between #{min_length} and #{max_length} characters"
+        end
+
+        private
+
+        def validate_core_fields(params)
+          validate_presence_and_type(params, :reference_id, String)
+          validate_string_length(params[:reference_id], 'reference_id', 1, 255)
+
+          validate_presence_and_type(params, :channel_code, String)
+          validate_presence_and_type(params, :channel_properties, Hash)
+          validate_amount(params[:amount])
+          validate_presence_and_type(params, :currency, String)
+        end
+
+        def validate_amount(amount)
+          raise ArgumentError, 'amount is required and should be an Integer or Float' \
+            unless amount.is_a?(Integer) || amount.is_a?(Float)
+
+          raise ArgumentError, 'amount must be greater than or equal to 0' \
+            if amount.negative?
+        end
+
+        def validate_optional_fields(params)
+          validate_description(params[:description]) if params[:description]
+          return unless params[:receipt_notification] || params[:metadata]
+
+          validate_receipt_notification(params[:receipt_notification]) if params[:receipt_notification]
+          validate_metadata(params[:metadata]) if params[:metadata]
+        end
+
+        def validate_channel_properties(properties)
+          validate_required_channel_fields(properties)
+          validate_channel_field_lengths(properties)
+          validate_account_type(properties[:account_type]) if properties[:account_type]
+        end
+
+        def validate_required_channel_fields(properties)
+          raise ArgumentError, 'channel_properties must contain account_holder_name' \
+            unless properties[:account_holder_name]
+
+          raise ArgumentError, 'channel_properties must contain account_number' \
+            unless properties[:account_number]
+        end
+
+        def validate_channel_field_lengths(properties)
+          validate_string_length(
+            properties[:account_holder_name],
+            'channel_properties.account_holder_name',
+            1,
+            100
+          )
+
+          validate_string_length(
+            properties[:account_number],
+            'channel_properties.account_number',
+            1,
+            100
+          )
+        end
+
+        def validate_account_type(account_type)
+          valid_types = %w[MOBILE_NO NATIONAL_ID PASSPORT BUSINESS_REGISTRATION BANK_ACCOUNT]
+          return if valid_types.include?(account_type)
+
+          raise ArgumentError, "account_type must be one of: #{valid_types.join(', ')}"
+        end
+
+        def validate_description(description)
+          validate_string_length(description, 'description', 1, 100)
+        end
+
+        def validate_receipt_notification(notification)
+          raise ArgumentError, 'receipt_notification must be a Hash' \
+            unless notification.is_a?(Hash)
+
+          %i[email_to email_cc email_bcc].each do |field|
+            validate_email_field(notification, field)
+          end
+        end
+
+        def validate_email_field(notification, field)
+          return unless notification[field]
+
+          raise ArgumentError, "#{field} must be an Array" \
+            unless notification[field].is_a?(Array)
+
+          raise ArgumentError, "#{field} can contain maximum 3 email addresses" \
+            if notification[field].length > 3
+        end
+
+        def validate_metadata(metadata)
+          return if metadata.nil?
+
+          raise ArgumentError, 'metadata must be a Hash' \
+            unless metadata.is_a?(Hash)
+
+          raise ArgumentError, 'metadata can contain maximum 50 keys' \
+            if metadata.keys.length > 50
+
+          metadata.each do |key, value|
+            validate_metadata_entry(key, value)
+          end
+        end
+
+        def validate_metadata_entry(key, value)
+          raise ArgumentError, "metadata key '#{key}' must be max 40 characters" \
+            if key.to_s.length > 40
+
+          raise ArgumentError, "metadata value for key '#{key}' must be max 500 characters" \
+            if value.to_s.length > 500
+        end
+
+        def validate_presence_and_type(params, key, type)
+          value = params[key]
+          types = type.is_a?(Array) ? type : [type]
+
+          return if value && types.any? { |t| value.is_a?(t) }
+
+          type_names = types.map(&:to_s).join(' or ')
+          raise ArgumentError, "#{key} is required and should be a #{type_names}"
+        end
+      end
+    end
+  end
+end

--- a/lib/xendit/resources.rb
+++ b/lib/xendit/resources.rb
@@ -1,3 +1,4 @@
 # frozen_string_literal: true
 
 require_relative 'resources/invoice'
+require_relative 'resources/payment_request'

--- a/lib/xendit/resources.rb
+++ b/lib/xendit/resources.rb
@@ -2,3 +2,4 @@
 
 require_relative 'resources/invoice'
 require_relative 'resources/payment_request'
+require_relative 'resources/payout'

--- a/lib/xendit/resources/payment_request.rb
+++ b/lib/xendit/resources/payment_request.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require 'faraday'
+require 'json'
+
+require_relative '../api_operations'
+require_relative '../response'
+
+module Xendit
+  class PaymentRequest
+    class << self
+      def get(payment_request_id, headers: {})
+        # validation
+        raise ArgumentError, 'payment_request_id is required and should be a string' \
+            if payment_request_id.nil? || !payment_request_id.is_a?(String)
+        raise ArgumentError, 'payment_request_id must be 39 characters' \
+            if payment_request_id.length != 39
+
+        request_headers = build_headers(headers)
+
+        resp = Xendit::APIOperations.get("v3/payment_requests/#{payment_request_id}", nil, headers: request_headers)
+        Xendit::Response.handle_error_response resp
+
+        JSON.parse resp.body
+      end
+
+      def create(payment_request_params, headers: {})
+        # validation
+        raise ArgumentError, 'payment_request_params is required' \
+            if payment_request_params.nil? || payment_request_params.empty?
+
+        # Validate required fields based on type
+        validate_required_fields(payment_request_params)
+
+        # Build headers
+        request_headers = build_headers(headers)
+
+        resp = Xendit::APIOperations.post(
+          'v3/payment_requests',
+          headers: request_headers,
+          **payment_request_params
+        )
+        Xendit::Response.handle_error_response resp
+
+        JSON.parse resp.body
+      end
+
+      private
+
+      def validate_required_fields(params)
+        validate_presence_and_type(params, :reference_id, String)
+        validate_inclusion(params, :type, %w[PAY PAY_AND_SAVE REUSABLE_PAYMENT_CODE])
+        validate_inclusion(params, :country, %w[ID PH VN TH SG MY])
+        validate_inclusion(params, :currency, %w[IDR PHP VND THB SGD MYR USD])
+        validate_presence_and_type(params, :channel_code, String)
+        validate_presence_and_type(params, :channel_properties, Hash)
+
+        # request_amount is required only if type is not REUSABLE_PAYMENT_CODE
+        return if params[:type] == 'REUSABLE_PAYMENT_CODE'
+
+        validate_request_amount(params[:request_amount])
+      end
+
+      def build_headers(custom_headers)
+        headers = {}
+        headers['api-version'] = custom_headers[:api_version] || custom_headers['api-version'] || '2024-11-11'
+        headers
+      end
+
+      def validate_presence_and_type(params, key, type)
+        value = params[key]
+        raise ArgumentError, "#{key} is required and should be a #{type}" if value.nil? || !value.is_a?(type)
+      end
+
+      def validate_inclusion(params, key, allowed_values)
+        value = params[key]
+        raise ArgumentError, "#{key} is required and should be one of: #{allowed_values.join(', ')}" \
+            if value.nil? || !allowed_values.include?(value)
+      end
+
+      def validate_request_amount(amount)
+        raise ArgumentError, 'request_amount is required and should be a number' \
+            if amount.nil? || (!amount.is_a?(Integer) && !amount.is_a?(Float))
+        raise ArgumentError, 'request_amount must be greater than or equal to 0' if amount.negative?
+      end
+    end
+  end
+end

--- a/lib/xendit/resources/payout.rb
+++ b/lib/xendit/resources/payout.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require 'faraday'
+require 'json'
+
+require_relative '../api_operations'
+require_relative '../response'
+require_relative '../payout/validator'
+
+module Xendit
+  class Payout
+    class << self
+      def get(payout_id, headers: {})
+        Validator.validate_payout_id(payout_id)
+        request_headers = build_headers(headers)
+
+        resp = Xendit::APIOperations.get("v2/payouts/#{payout_id}", nil, headers: request_headers)
+        Xendit::Response.handle_error_response resp
+
+        JSON.parse resp.body
+      end
+
+      def get_by_reference_id(reference_id, headers: {})
+        raise ArgumentError, 'reference_id is required and should be a string' \
+          if reference_id.nil? || !reference_id.is_a?(String)
+
+        request_headers = build_headers(headers)
+        params = {reference_id: reference_id}
+
+        resp = Xendit::APIOperations.get('v2/payouts', params, headers: request_headers)
+        Xendit::Response.handle_error_response resp
+
+        JSON.parse resp.body
+      end
+
+      def create(payout_params, headers: {})
+        raise ArgumentError, 'payout_params is required' \
+          if payout_params.nil? || payout_params.empty?
+
+        Validator.validate_payout_params(payout_params)
+        request_headers = build_headers(headers, payout_params)
+
+        resp = Xendit::APIOperations.post(
+          'v2/payouts',
+          headers: request_headers,
+          **payout_params
+        )
+        Xendit::Response.handle_error_response resp
+
+        JSON.parse resp.body
+      end
+
+      private
+
+      def build_headers(custom_headers, payout_params = {})
+        headers = {}
+
+        # Idempotency-key is required (1-100 characters)
+        idempotency_key = custom_headers[:idempotency_key] ||
+                          custom_headers['Idempotency-key'] ||
+                          payout_params[:reference_id]
+
+        raise ArgumentError, 'Idempotency-key is required in headers' if idempotency_key.nil?
+
+        Validator.validate_string_length(idempotency_key, 'Idempotency-key', 1, 100)
+        headers['Idempotency-key'] = idempotency_key
+        headers
+      end
+    end
+  end
+end

--- a/lib/xendit/response.rb
+++ b/lib/xendit/response.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_relative './errors'
+require_relative 'errors'
 
 module Xendit
   class Response

--- a/lib/xendit/version.rb
+++ b/lib/xendit/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Xendit
-  VERSION = '1.0.0'
+  VERSION = '1.1.0'
 end

--- a/lib/xendit/version.rb
+++ b/lib/xendit/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Xendit
-  VERSION = '1.1.0'
+  VERSION = '1.2.0'
 end


### PR DESCRIPTION
This PR introduces full support for the **Payment Request API** into the Xendit Ruby SDK and bumps the gem version to **v1.1.0**.

---

# Changes Included

### **New Features**

* Added new `PaymentRequest` resource:

  * `Xendit::PaymentRequest.create`
  * `Xendit::PaymentRequest.get`
* Added support for:

  * Card payments
  * E-wallet payments (e.g., GCash)
  * QR / reusable payment codes
  * Manual capture payments
  * PAY_AND_SAVE type
  * Customer details object
  * Custom XenPlatform headers:

    * `api_version`
    * `for_user_id`
    * `with_split_rule`

### **Other Updates**

* Added complete usage examples for all Payment Request flows
* Updated and expanded `README.md`
* Bumped gem version to **1.1.0**
* General code improvements and cleanup
---
